### PR TITLE
區別辦完與舉辦中的活動

### DIFF
--- a/app/app.ls
+++ b/app/app.ls
@@ -43,8 +43,9 @@ angular.module "g0v.tw" <[firebase btford.markdown]>
 
 .controller EventCtrl: <[$scope eventsPromise]> ++ ($scope, eventsPromise) ->
   eventsPromise.then (events) ->
-    $scope.events = (events.recent ++ events.past) .slice 0 2
-    console.log $scope.events
+    recent = events.recent.map (it) -> it.finished = false; it
+    past = events.past.map (it) -> it.finished = true; it
+    $scope.events = (recent ++ past)
 
 .controller BlogCtrl: <[$scope angularFireCollection fireRoot]> ++ ($scope, angularFireCollection, fireRoot) ->
   $scope.articles = angularFireCollection fireRoot.child("feed/blog/articles").limit 4

--- a/app/index.jade
+++ b/app/index.jade
@@ -68,9 +68,11 @@ block content
 
             .event-loading(ng-show="events.length === 0")
             h4 最新活動
-                ul
-                    li(ng-repeat="event in events | orderBy:'$index':true")
-                        a(ng-href="{{event.link}}") {{event.title}}
+                .ui.list
+                    .item(ng-repeat="event in events | limitTo:2")
+                        i(ng-class="{checked:event.finished, empty:!event.finished}").checkbox.icon
+                        .content
+                            a(ng-href="{{event.link}}") {{event.title}}
 
             .ui.divider
             .videos


### PR DESCRIPTION
用 semantic ui checkbox icon 來區別,
- empty checkbox: 舉辦中
- checked checkbox: 已辦完

這次 commit 做出以下變更:
1. 拿掉遺留的 console.log ... Q_Q
2. 因應 ui.list, markup 從 ul/li 改成 div.ui.list
3. 在 events object 中加上 finished 標記供 template 辨認
4. 截斷陣列的工作由 controller 轉移給 filter
5. 刪除 orderBy:'$index':true", 不知為何有它反而順序會錯亂

Close #59 
