### PR TITLE
fixed #116 less build error should stop gulp.

### DIFF
--- a/gulpfile.ls
+++ b/gulpfile.ls
@@ -69,7 +69,7 @@ gulp.task 'js:app', ->
 gulp.task 'css', ->
   compress = production
   gulp.src 'app/styles/app.less'
-    .pipe gulp-plumber!
+    .pipe gulp-if !production, gulp-plumber!
     .pipe gulp-less compress: compress
     .pipe gulp.dest "#{build_path}/css"
 


### PR DESCRIPTION
```
$ NODE_ENV=production
$ ./node_modules/.bin/gulp --env production
```

Signed-off-by: Bo-Yi Wu appleboy.tw@gmail.com
