### PR TITLE
把小松的紀錄從 github issue 取得改成從設定檔

### DIFF
--- a/app/app.ls
+++ b/app/app.ls
@@ -37,13 +37,7 @@ angular.module "g0v.tw" <[firebase btford.markdown pascalprecht.translate]>
 .controller EventCtrl: <[$q $http $scope]> ++ ($q, $http, $scope) ->
   $scope.events = []
 
-  $scope.event-sources = <[
-    http://g0v-jothon.kktix.cc/events.json
-    http://g0v-tw.kktix.cc/events.json
-    http://moe.kktix.cc/events.json
-    http://g0vlawthon.kktix.cc/events.json
-    http://fr0ntend.kktix.cc/events.json
-  ]>
+  $scope.event-sources = []
 
   $scope.events-of = (url) ->
     defer = $q.defer()
@@ -51,22 +45,18 @@ angular.module "g0v.tw" <[firebase btford.markdown pascalprecht.translate]>
       defer.resolve([event if moment(event.published).diff(moment()) > 0 for event in result.entry])
     return defer.promise
 
-  $scope.from-github = ->
+  $scope.from-smallthon-config= ->
     defer = $q.defer!
     result <- $http
-      .get 'https://api.github.com/repos/g0v/g0v.tw/issues/127/comments'
+      .get '/data/small-thon.json'
       .success
     defer.resolve result
     return defer.promise
 
   { data } <- $scope
-    .from-github!
+    .from-smallthon-config!
     .then
-  re = /http:\/\/(.+\.cc)\/?/
-  $scope.event-sources = $scope.event-sources.concat ( data
-    .filter -> re.test it.body
-    .map -> "http://#{it.body.match re .1}/events.json"
-  )
+  $scope.event-sources = data.map -> it + "/events.json"
 
   $scope.event-sources.map (source) ->
     $scope.events-of(source)

--- a/app/assets/data/small-thon.json
+++ b/app/assets/data/small-thon.json
@@ -1,0 +1,9 @@
+[
+    "http://g0v-jothon.kktix.cc"
+    ,"http://g0v-tw.kktix.cc"
+    ,"http://moe.kktix.cc"
+    ,"http://g0vlawthon.kktix.cc"
+    ,"http://fr0ntend.kktix.cc"
+    ,"http://poponfire.kktix.cc"
+    ,"http://g0v-summit2016.kktix.cc"
+]

--- a/gulpfile.ls
+++ b/gulpfile.ls
@@ -109,6 +109,7 @@ gulp.task 'watch', <[ build server ]> ->
   gulp-livereload.listen silent: true
   gulp.watch [
     'app/**/*.jade',
+    'app/assets/data/*',
     \app/assets/translations/*.json.ls,
     'md/**/*.md'
   ], <[ html ]> .on \change, gulp-livereload.changed


### PR DESCRIPTION
原來的小松列表是用 GitHub API 從  https://github.com/g0v/g0v.tw/issues/127 抓包含 kktix.cc 的網址
現在改成寫在 /app/assets/data/small-thon.json
這樣寫法就比較不會因為 GitHub API 過量造成出問題了 