### PR TITLE
add phantomjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "mocha": "^2.1.0",
     "streamqueue": "^0.1.0",
     "tiny-lr": "^0.1.5"
+  },
+  "dependencies": {
+    "phantomjs": "^2.1.7"
   }
 }


### PR DESCRIPTION
新增 phantomjs dependency 讓npm install 可以先安裝 phantomjs 在node 4.X.X的版本