### PR TITLE
Correct "join slack" URL

### DIFF
--- a/app/partials/index.jade
+++ b/app/partials/index.jade
@@ -98,7 +98,7 @@ block content
           .g0vslack
               h4(translate="HOME_SLACK") 加入 g0v.tw Slack
               p 現在 IRC 與 Slack 已經同步囉！
-              a(target="_blank",class="ui blue small button",href="http://join.g0v.today/") 立刻申請加入 Slack
+              a(target="_blank",class="ui blue small button",href="http://join.g0v.tw/") 立刻申請加入 Slack
           .ui.divider
           .logbot
               h4

--- a/md/zh-tw/about/contact.md
+++ b/md/zh-tw/about/contact.md
@@ -6,7 +6,7 @@
 * [公共郵件論壇](https://groups.google.com/forum/?fromgroups#!forum/g0v-general)
 * 線上聊天室（兩入口殊途同歸）：
  * [irc](http://hack.g0v.tw/irc)
- * [slack](http://join.g0v.today)
+ * [slack](http://join.g0v.tw)
 
 #### 採訪/演講邀約：如無特定人選可來信至 g0v-talks 群組，社群將協調是否有適合人選
 * g0v-talks [at] googlegroups.com（[g0v-talks 群組介紹](https://g0v.hackpad.tw/g0v-Media-Policy--Rbpc5FiUyA5#:h=什麼是-g0v-talks-小組))


### PR DESCRIPTION
Fix the broken link on the index page and document.

Similar to #184 and #185